### PR TITLE
Update rules for combining line and branch coverage

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -24,10 +24,10 @@ export const combineLines = (a: Lines, b: Lines): Lines => {
   return a.map((lhs, index) => {
     const rhs = b[index];
 
-    if (lhs === null && rhs === null) return null;
-    if (lhs !== null && rhs !== null) return lhs + rhs;
+    // Coerce nulls to zeros
+    const sum = Number(lhs) + Number(rhs);
 
-    throw new Error('combineLines: difference in SLOC');
+    return !sum && (lhs == null || rhs == null) ? null : sum;
   });
 };
 
@@ -44,8 +44,8 @@ export const combineBranches = (
   a: Branches | undefined,
   b: Branches | undefined,
 ): Branches | undefined => {
-  if (a === undefined) return b;
-  if (b === undefined) return a;
+  if (a === undefined || Object.keys(a).length === 0) return b;
+  if (b === undefined || Object.keys(b).length === 0) return a;
 
   const aEntries = Object.entries(a);
   const bEntries = Object.entries(b);


### PR DESCRIPTION
I originally based this off the [Ruby 3 coverage docs](https://devdocs.io/ruby~3.3/coverage), but this seems to not quite match with what simplecov is doing.

It looks like I missed what's [actually in simplecov](https://github.com/simplecov-ruby/simplecov/tree/main/lib/simplecov/combine). Some of the assumptions there look kinda iffy to me, but I used that as a canonical reference, and only needed a couple of changes to apparently fix the problems I had when not using `SimpleCov.collate`. Now my numbers after combining multiple runs using the builtin merging agree with what SimpleCov says.

In particular, some result sets show lines with a zero (no coverage) and different runs have a null (not a significant LOC). This seems pretty weird, and simplecov's rules for resolving that don't make a ton of sense to me. The net effect is that I run test from two sources, they don't agree on the number of LOC, and after combining, the ultimate result shows fewer LOC than either run reports. But...it matches what simplecov says, so leaving it there for now.
